### PR TITLE
Changed parameters to accept IUnityContainer

### DIFF
--- a/src/Hangfire.Unity/UnityBootstrapperConfigurationExtensions.cs
+++ b/src/Hangfire.Unity/UnityBootstrapperConfigurationExtensions.cs
@@ -19,7 +19,7 @@ namespace Hangfire
         /// </summary>
         /// <param name="configuration">Configuration</param>
         /// <param name="container">The unity container that will be used to activate jobs</param>
-        public static void UseUnityActivator(this IBootstrapperConfiguration configuration, UnityContainer container)
+        public static void UseUnityActivator(this IBootstrapperConfiguration configuration, IUnityContainer container)
         {
             configuration.UseActivator(new UnityJobActivator(container));
         }

--- a/src/Hangfire.Unity/UnityJobActivator.cs
+++ b/src/Hangfire.Unity/UnityJobActivator.cs
@@ -12,13 +12,13 @@ namespace Hangfire.Unity
     /// </summary>
     public class UnityJobActivator : JobActivator
     {
-        private readonly UnityContainer container;
+        private readonly IUnityContainer container;
 
         /// <summary>
         /// Initialize a new instance of the <see cref="T:UnityJobActivator"/> class
         /// </summary>
         /// <param name="container">The unity container to be used</param>
-        public UnityJobActivator(UnityContainer container)
+        public UnityJobActivator(IUnityContainer container)
         {
             if (container == null)
                 throw new ArgumentNullException("container");


### PR DESCRIPTION
It's nice to ask for a Interface instead of the concrete
implementation in method parameters. Since the package
Unity.AspNet.WebApi uses the interface IUnityContainer to configure a Unity container
in a WebApi, we should also use the interface IUnityContainer in
HangFire. And its compatible with clients already using this package.

So instead of:

``` c#
config.UseUnityActivator(UnityConfig.GetConfiguredContainer() as Microsoft.Practices.Unity.UnityContainer);
```

now i can use:

``` c#
  config.UseUnityActivator(UnityConfig.GetConfiguredContainer());
```
